### PR TITLE
util.spam: Add new strategy to check for "no reply" email address, ex…

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -26,3 +26,4 @@ jobs:
 
     - name: Run tests
       run: sbt test
+

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,0 +1,31 @@
+
+name: Scala CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: 'sbt'
+    - name: Run tests
+      run: sbt test
+      # This (optional) step uploads information to the GitHub dependency graph and unblocking
+      # Dependabot alerts for the repository.
+    - name: Upload dependency graph
+      uses: scalacenter/sbt-dependency-submission@ab086b50c947c9774b70f39fc7f6e20ca2706c91

--- a/project/build.scala
+++ b/project/build.scala
@@ -1,4 +1,4 @@
 
 package object build {
-  val libVersion = "0.13.0"
+  val libVersion = "0.14.0"
 }

--- a/test/co/spendabit/util/spam/SpamDetectionTests.scala
+++ b/test/co/spendabit/util/spam/SpamDetectionTests.scala
@@ -472,6 +472,15 @@ class SpamDetectionTests extends FunSuite {
         "click here to accept it and chat with her. She is online.\n" +
         "https://sexlovers.club/chat/HornyShriya/")
 
+    assertDetectedAsSpam(
+      from = "Phil Stewart <noreplyhere@aol.com>",
+      "Want Your Ad Everywhere? Reach Millions Instantly! For less than $100 I can blast " +
+        "your message to website contact forms globally. Contact me via skype or email below for " +
+        "info\n\n" +
+        "P. Stewart\n" +
+        "Email: ws5gp6@submitmaster.xyz\n" +
+        "Skype: form-blasting")
+
     pending
 
     assertConsideredLikelyToBeSpam(


### PR DESCRIPTION
util.spam: Add new strategy to check for "no reply" email address, extend existing strategy that checks for free email services (Yahoo, Gmail) to also check for aol.com, and do a bit of minor refactoring; relevant testing included via SpamDetectionTests.