### PR TITLE
Upgrade sbt and tweak sbt config (build file) to use new built-in sbt support for publishing to the "Central" repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ After ensuring the test-suite passes (`sbt "+ test"`), run the following two
 commands on the `sbt` console:
 ```
 + publishSigned
-sonatypeRelease
+sonaUpload
+sonaRelease
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import xerial.sbt.Sonatype.SonatypeKeys.sonatypeProfileName
 
 organization := "co.spendabit"
 
@@ -25,7 +24,11 @@ libraryDependencies ++= Seq(
 
 publishMavenStyle := true
 
-publishTo := sonatypePublishToBundle.value
+ThisBuild / publishTo := {
+  val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
+  if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
+  else localStaging.value
+}
 
 (Test / publishArtifact) := false
 
@@ -50,8 +53,6 @@ pomExtra :=
       <organizationUrl>https://spendabit.co/</organizationUrl>
     </developer>
   </developers>
-
-sonatypeProfileName := "co.spendabit"
 
 (Compile / scalaSource) := { (Compile / baseDirectory)(_ / "src") }.value
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.12.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,1 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.11.1")
-
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")


### PR DESCRIPTION
Upgrade sbt and tweak sbt config (build file) to use new built-in sbt support for publishing to the "Central" repository.